### PR TITLE
Added a "verbose" option and refactored the logging a bit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,18 @@ grunt.initConfig({
 ### Options
 
 #### options.priorities
-Type: `Object`
+Type: `Object`  
 Default value: `{ low : /TODO/, med : /FIXME/, high : null }`
 
 An object that specifies what the various priorities are for the target.
 High will add to the errorCount.
+
+
+#### options.verbose
+Type: `Boolean`  
+Default value: `true`
+
+Verbose mode will cause the plugin to report on every file, regardles if there are actual lines to report or not. If set to false, only files with todos will be mentioned.
 
 ### Usage Examples
 
@@ -59,6 +66,7 @@ grunt.initConfig({
 ```
 
 #### Custom Options
+
 In this example, custom options are used to escalate TODO to med priority.
 
 ```js
@@ -71,6 +79,19 @@ grunt.initConfig({
         }
     },
     src : ['src/testing', 'src/123']
+  }
+})
+```
+
+In this example, we want minimize the total output by setting `verbose` to false.
+
+```js
+grunt.initConfig({
+  todos: {
+    options: {
+        verbose: false
+    },
+    src : ['src/**/*.js']
   }
 })
 ```


### PR DESCRIPTION
The plugin was displaying every single file while it was running and the "no tasks found" wasn't really working (was never displayed because syntax.comments was always > 0 if the file had any comments).

I changed "logComments" to "detectComments" which will now push onto a (relevant)comments stack before the actualy reporting logic is executed. 

That allowed me add the required conditions and i could also fix the missing "no tasks found" report at the same time.

My changes will not affect the original behavior. It is only an option to reduce the amount of files reported down to only those that are relevant (ie. contain a TODO/FIXME, etc).

HTH

_ps; i would have written tests, but all current ones were failing anyway so i am not sure where to start. I think the entire suite must be fixed. Probably outdated or something._
