### PR TITLE
Minor readme fix for the verbose example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ grunt.initConfig({
 })
 ```
 
-In this example, we want minimize the total output by setting `verbose` to false.
+In this example, the options will limit the output to report only files that contain tasks.
 
 ```js
 grunt.initConfig({


### PR DESCRIPTION
I left out a word in the verbose example description + it was kinda hard to read. 

Couldn't leave it like that. :yum:  
